### PR TITLE
Adjust for blue ocean URLs on config set to true

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ The Jenkins masters are configured in the config/masters.json file.
 The configuration file has one key, ``masters``, which holds a list of jenkins master configuration objects. Each jenkins master has three keys
   - name - The name of the server
   - endpoint - The base endpoint of the server
-  - icon - Link to an icon to display next to jobs from this master  
+  - icon - Link to an icon to display next to jobs from this master
+  - blueocean - set to true if you are using the Jenkins blueocean UI plugin
 
 Sample masters.json:
 ```
@@ -32,12 +33,14 @@ Sample masters.json:
     {
       "name": "Alfred",
       "endpoint": "http://alfred.your.domain.com",
-      "icon": "http://alfred.your.domain.com/userContent/logo.png"
+      "icon": "http://alfred.your.domain.com/userContent/logo.png",
+      "blueocean": false
     },
     {
       "name": "Banks",
       "endpoint": "http://banks.your.domain.com",
-      "icon": "http://banks.your.domain.com/userContent/logo.png"
+      "icon": "http://banks.your.domain.com/userContent/logo.png",
+      "blueocean": true
     }
   ]
 }

--- a/config/masters.json
+++ b/config/masters.json
@@ -3,7 +3,8 @@
     {
       "name": "MASTER_NAME",
       "endpoint": "http://MASTER_URL",
-      "icon": "http://MASTER_ICON"
+      "icon": "http://MASTER_ICON",
+      "blueocean": false
     }
   ]
 }

--- a/lib/superMaster.js
+++ b/lib/superMaster.js
@@ -19,7 +19,7 @@ SuperMaster.prototype.getJobs = function(callback){
       if(err || res.statusCode != 200 ){
         if(res && res.statusCode != 200)
           err = new Error(res.statusMessage);
-        
+
         console.warn("Request to", master.name, "failed.\nMessage:", err.message);
         jobs = self.cache[master.name]; // Set jobs from cache
 
@@ -30,6 +30,11 @@ SuperMaster.prototype.getJobs = function(callback){
         jobs = JSON.parse(body).jobs;
 
         jobs.forEach((job) => {
+          job.config = job.url + "configure"
+          if (master.blueocean){
+            job.url = master.endpoint + "/blue/organizations/jenkins/" + job.name + "/branches"
+          }
+
           job.master = master.name;
           job.icon = master.icon || "";
         });

--- a/public/index.handlebars
+++ b/public/index.handlebars
@@ -51,7 +51,7 @@
               </i>
             </td>
             <td class="result-config">
-              <a href="{[{ job.url }]}configure" title="Configure" target="_blank">
+              <a href="{[{ job.config }]}" title="Configure" target="_blank">
                 <i class="fa fa-cog fa-2x"></i>
               </a>
             </td>


### PR DESCRIPTION
Allow super jenkins users to specify one of their masters is using the [blue ocean UI plugin](https://github.com/jenkinsci/blueocean-plugin).  Links to the jenkins jobs will go into blue ocean instead of vanilla Jenkins job listing.  Enabled if true, disabled if false in the masters.json config file.